### PR TITLE
Initializing an empty array of pixels is not required.

### DIFF
--- a/image_registration/model/region.py
+++ b/image_registration/model/region.py
@@ -94,8 +94,6 @@ class Region(object):
         :return:
         """
         self.bounding_region = vertices
-        w, h = self._get_width_and_height(vertices)
-        self.pixels = [[Pixel(0, 0, 0) for x in range(int(w))] for y in range(int(h))]
 
     def set_pixel(self, x, y, pixel):
         """


### PR DESCRIPTION
Images are read and processed on the fly, hence it is not required to create and initialize an empty array of pixels. 